### PR TITLE
Missing memory method

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
   var dummy = function() {};
   var methods = ('assert,count,debug,dir,dirxml,error,exception,group,' +
      'groupCollapsed,groupEnd,info,log,markTimeline,profile,profileEnd,' +
-     'time,timeEnd,trace,warn').split(',');
+     'time,timeEnd,trace,warn, memory').split(',');
   while (method = methods.pop()) {
     con[method] = con[method] || dummy;
   }


### PR DESCRIPTION
add memory to method list - fails in firefox otherwise
