### PR TITLE
use window instead of this so that we can browserify this module

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,4 +12,4 @@
      'table,time,timeEnd,timeStamp,trace,warn').split(',');
   while (prop = properties.pop()) con[prop] = con[prop] || empty;
   while (method = methods.pop()) con[method] = con[method] || dummy;
-})(this.console = this.console || {});
+})(window.console = window.console || {});


### PR DESCRIPTION
I am using this to polyfill older browsers, but since common.js and browserify wrap a closure around modules, `this !== window`

Changed this to window.
