### PR TITLE
adding missing methods in firefox and safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@
   var dummy = function() {};
   var properties = 'memory'.split(',');
   var methods = ('assert,clear,count,debug,dir,dirxml,error,exception,group,' +
-     'groupCollapsed,groupEnd,info,log,markTimeline,profile,profileEnd,' +
-     'table,time,timeEnd,timeStamp,trace,warn').split(',');
+     'groupCollapsed,groupEnd,info,log,markTimeline,profile,profiles,profileEnd,' +
+     'show,table,time,timeEnd,timeline,timelineEnd,timeStamp,trace,warn').split(',');
   while (prop = properties.pop()) con[prop] = con[prop] || empty;
   while (method = methods.pop()) con[method] = con[method] || dummy;
 })(this.console = this.console || {}); // Using `this` for web workers.


### PR DESCRIPTION
I added 3 methods (profiles, timeline, timelineEnd) which are now available in Safari and Firefox.
