### PR TITLE
Bind Function.prototype to console methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,13 @@
      'groupCollapsed,groupEnd,info,log,markTimeline,profile,profiles,profileEnd,' +
      'show,table,time,timeEnd,timeline,timelineEnd,timeStamp,trace,warn').split(',');
   while (prop = properties.pop()) if (!con[prop]) con[prop] = empty;
-  while (method = methods.pop()) if (!con[method]) con[method] = dummy;
+  while (method = methods.pop()) {
+    if (!con[method]) {
+      con[method] = dummy;
+    } else if (Function.prototype.bind && typeof con[method] === 'object') {
+      con[method] = Function.prototype.bind.call(con[method], con);
+    }
+  }
 })(typeof window === 'undefined' ? this : window);
 // Using `this` for web workers while maintaining compatibility with browser
 // targeted script loaders such as Browserify or Webpack where the only way to


### PR DESCRIPTION
#### What does this PR do?

* Binds `Function.prototype` to console methods if needed and when supported
* Enables use of `apply`/`call` as in `console.log.apply(console, messages)` in IE9

#### Additional background

Excerpted from the following StackOverflow post (http://stackoverflow.com/questions/5538972/console-log-apply-not-working-in-ie9?rq=1)

>  The console object is not part of any standard and is an extension to the Document Object Model. Like other DOM objects, it is considered a host object and is not required to inherit from Object, nor its methods from Function, like native ECMAScript functions and objects do. This is the reason apply and call are undefined on those methods. In IE 9, most DOM objects were improved to inherit from native ECMAScript types. As the developer tools are considered an extension to IE (albeit, a built-in extension), they clearly didn't receive the same improvements as the rest of the DOM.

#### Related

This PR, combined with a `Function.bind` shim for IE8 should also resolve https://github.com/paulmillr/console-polyfill/issues/8