### PR TITLE
Checking the type of a method

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
      'groupCollapsed,groupEnd,info,log,markTimeline,profile,profiles,profileEnd,' +
      'show,table,time,timeEnd,timeline,timelineEnd,timeStamp,trace,warn').split(',');
   while (prop = properties.pop()) if (!con[prop]) con[prop] = empty;
-  while (method = methods.pop()) if (!con[method]) con[method] = dummy;
+  while (method = methods.pop()) if (typeof con[method] !== 'function') con[method] = dummy;
 })(typeof window === 'undefined' ? this : window);
 // Using `this` for web workers while maintaining compatibility with browser
 // targeted script loaders such as Browserify or Webpack where the only way to


### PR DESCRIPTION
I found myself in a case in which for unknown reasons the methods in `global.console` where already defined but they were objects (possibly another attempt to polyfill by someone else that I need to better investigate in my codebase). 

To my understanding the methods are supposed to be functions, therefore I propose this change to rectify possible problems related to a previous definition of `console`. 