### PR TITLE
Size optimizations

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,12 @@
   global.console = global.console || {};
   var con = global.console;
   var prop, method;
-  var empty = {};
   var dummy = function() {};
-  var properties = 'memory'.split(',');
+  var properties = ['memory'];
   var methods = ('assert,clear,count,debug,dir,dirxml,error,exception,group,' +
      'groupCollapsed,groupEnd,info,log,markTimeline,profile,profiles,profileEnd,' +
      'show,table,time,timeEnd,timeline,timelineEnd,timeStamp,trace,warn').split(',');
-  while (prop = properties.pop()) if (!con[prop]) con[prop] = empty;
+  while (prop = properties.pop()) if (!con[prop]) con[prop] = {};
   while (method = methods.pop()) if (typeof con[method] !== 'function') con[method] = dummy;
   // Using `this` for web workers & supports Browserify / Webpack.
 })(typeof window === 'undefined' ? this : window);


### PR DESCRIPTION
- No need to split string with one element
- var empty used just once.