### PR TITLE
Only clobber global.console if it's not already there.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@
 // Make it safe to do console.log() always.
 (function(global) {
   'use strict';
-  global.console = global.console || {};
+  if (!global.console) {
+    global.console = {};
+  }
   var con = global.console;
   var prop, method;
   var dummy = function() {};


### PR DESCRIPTION
The [specification indicates](https://developer.mozilla.org/en-US/docs/Web/API/Window) that `window.console` is read-only when defined. The [Domino](https://github.com/fgnass/domino) window library for node js tests implements this correctly as read-only.

When a library ([rollbar-browser](https://rollbar.com/docs/notifier/rollbar.js/)) is required that itself requires this library, the attempt to clobber the console property throws.