### PR TITLE
reverted for backwards compatibility with ie8

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@
      'groupCollapsed,groupEnd,info,log,markTimeline,profile,profiles,profileEnd,' +
      'show,table,time,timeEnd,timeline,timelineEnd,timeStamp,trace,warn').split(',');
   while (prop = properties.pop()) if (!con[prop]) con[prop] = {};
-  while (method = methods.pop()) if (typeof con[method] !== 'function') con[method] = dummy;
+  while (method = methods.pop()) if (!con[method]) con[method] = dummy;
   // Using `this` for web workers & supports Browserify / Webpack.
 })(typeof window === 'undefined' ? this : window);


### PR DESCRIPTION
I'm not sure why, but commit bf879365981e925647cb2a012cd188a889c10f85 changed how attributes were checked on the console object.  This broke compatibility with IE8. This PR reverts that commit.

On IE8, the current version of console-polyfill will just stop execution when it comes time to replace console.log.  No errors, nothing.  It just stops execution of the script.  This is certainly a bug in IE8, but can be worked around with this patch.